### PR TITLE
Rewrite repo with simple local LLM evaluation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+results/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,115 +1,48 @@
-# 🧪 Build Your Own Evals for Local LLMs
+# Local LLM Evals
 
-Test and benchmark **any** local large language model (LLM) with your own datasets.  
-Easily compare models, track results over time, and design custom evaluation pipelines.
+A tiny toolkit for running quick evaluations on local language models.  It trades
+fancy features for simplicity so you can benchmark models on a laptop with just a
+few commands.
 
----
-
-## 🚀 Features
-- **Plug & play model testing** — works with `Ollama`, `transformers`, `llama.cpp`, or any local model API.
-- **Custom datasets** — add your own `.jsonl` or `.csv` files for evaluation.
-- **Example tests included** — start with built-in QA, summarization, and reasoning evals.
-- **Simple metrics** — accuracy, BLEU, ROUGE, and custom scoring hooks.
-- **Repeatable results** — same tests, different models, comparable outputs.
-
----
-
-## 📦 Installation
+## Install
 
 ```bash
-git clone https://github.com/yourname/local-llm-evals.git
-cd local-llm-evals
 pip install -r requirements.txt
-🗂 Project Structure
-perl
-Copy
-Edit
-local-llm-evals/
-├── datasets/          # Example datasets (JSONL, CSV)
-├── tests/             # Example test scripts
-├── results/           # Saved run outputs + metrics
-├── evals/             # Core evaluation functions
-├── config.yaml        # Config for model + dataset selection
-└── README.md
-⚡ Quick Start
-Run a test with the default dataset and model:
+```
 
-bash
-Copy
-Edit
-python run_eval.py --model ollama:llama3 --dataset datasets/simple_qa.jsonl
-Example Output:
+To evaluate real models you also need a backend.  This project currently
+supports [Ollama](https://ollama.ai/) via its local HTTP API.  Install and run
+Ollama separately if you want to test actual models.
 
-yaml
-Copy
-Edit
-Model: llama3 (Ollama)
-Dataset: simple_qa
-Accuracy: 83%
-Avg Latency: 1.8s
-🧩 Adding Your Own Dataset
-Create a .jsonl file in datasets/:
+## Usage
 
-json
-Copy
-Edit
+```bash
+python run_eval.py --model echo --dataset datasets/simple_qa.jsonl
+```
+
+`--model` selects the backend:
+
+* `echo` – returns the prompt unchanged (useful for testing the pipeline).
+* `ollama:MODEL` – queries an Ollama model like `ollama:llama2`.
+
+Results show simple accuracy and average latency.  Use `--save results.json`
+to keep raw outputs.
+
+## Adding Datasets
+
+Datasets are newline‑delimited JSON files with at least a `prompt` field and an
+optional `expected` field used for scoring.
+
+```jsonl
 {"prompt": "What is the capital of France?", "expected": "Paris"}
 {"prompt": "2 + 2 =", "expected": "4"}
-Run:
+```
 
-bash
-Copy
-Edit
-python run_eval.py --model ollama:mistral --dataset datasets/my_dataset.jsonl
-🔬 Example Tests
-We include a few out of the box:
+Drop new files into the `datasets/` folder and reference them with
+`--dataset path/to/file.jsonl`.
 
-simple_qa.jsonl — Basic factual recall.
+## Why so minimal?
 
-math_reasoning.jsonl — Step-by-step math reasoning.
-
-summarization.jsonl — Text summarization scoring.
-
-📊 Metrics
-By default, we compute:
-
-Exact Match for QA
-
-String Similarity (Levenshtein)
-
-ROUGE / BLEU for summarization
-
-You can add your own metrics in evals/metrics.py.
-
-🔌 Supported Backends
-Ollama
-
-HuggingFace transformers (with AutoModelForCausalLM)
-
-llama.cpp
-
-Any custom API endpoint
-
-Switch models via:
-
-bash
-Copy
-Edit
-python run_eval.py --model transformers:meta-llama/Llama-2-7b-chat-hf
-📅 Roadmap
- Add multi-turn conversation evals
-
- Add leaderboard-style web UI
-
- Add noise injection / robustness tests
-
-🤝 Contributing
-Pull requests welcome!
-
-Fork it
-
-Create your feature branch
-
-Submit a PR
-
-
+The goal is to make running local model checks easy, even on a MacBook.
+The code favours readability over raw performance and keeps dependencies light.
+Feel free to extend it for your own experiments!

--- a/datasets/simple_qa.jsonl
+++ b/datasets/simple_qa.jsonl
@@ -1,0 +1,2 @@
+{"prompt": "What is the capital of France?", "expected": "Paris"}
+{"prompt": "2 + 2 =", "expected": "4"}

--- a/evals/metrics.py
+++ b/evals/metrics.py
@@ -1,0 +1,14 @@
+import difflib
+from typing import Optional
+
+def exact_match(predicted: str, expected: Optional[str]) -> bool:
+    """Return True if predicted matches expected exactly."""
+    if expected is None:
+        return False
+    return predicted.strip() == expected.strip()
+
+def levenshtein_similarity(predicted: str, expected: Optional[str]) -> float:
+    """Return a similarity score between 0 and 1 using difflib."""
+    if expected is None:
+        return 0.0
+    return difflib.SequenceMatcher(None, predicted.strip(), expected.strip()).ratio()

--- a/evals/model.py
+++ b/evals/model.py
@@ -1,0 +1,30 @@
+"""Lightweight model runners for local LLMs."""
+from __future__ import annotations
+
+import requests
+from typing import Callable
+
+
+def get_model(spec: str) -> Callable[[str], str]:
+    """Return a function that takes a prompt and returns a model response.
+
+    Supported specs:
+      - ``echo`` – returns the prompt unchanged. Useful for tests.
+      - ``ollama:MODEL`` – uses the local Ollama HTTP API.
+    """
+    if spec == "echo":
+        return lambda prompt: prompt
+
+    backend, _, name = spec.partition(":")
+    if backend == "ollama":
+        def run(prompt: str) -> str:
+            resp = requests.post(
+                "http://localhost:11434/api/generate",
+                json={"model": name, "prompt": prompt},
+                timeout=60,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("response", "").strip()
+        return run
+    raise ValueError(f"Unknown model spec: {spec}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/run_eval.py
+++ b/run_eval.py
@@ -1,0 +1,63 @@
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import List, Dict
+
+from evals.model import get_model
+from evals.metrics import exact_match, levenshtein_similarity
+
+
+def load_dataset(path: str) -> List[Dict[str, str]]:
+    data: List[Dict[str, str]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            data.append(json.loads(line))
+    return data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a simple evaluation")
+    parser.add_argument("--model", default="echo", help="Model spec, e.g. 'echo' or 'ollama:llama2'")
+    parser.add_argument("--dataset", default="datasets/simple_qa.jsonl", help="Path to JSONL dataset")
+    parser.add_argument("--save", default=None, help="Optional path to save raw results as JSON")
+    args = parser.parse_args()
+
+    dataset = load_dataset(args.dataset)
+    model = get_model(args.model)
+
+    correct = 0
+    results = []
+    start = time.time()
+    for row in dataset:
+        prompt = row["prompt"]
+        expected = row.get("expected")
+        output = model(prompt)
+        row_result = {
+            "prompt": prompt,
+            "expected": expected,
+            "output": output,
+        }
+        row_result["exact_match"] = exact_match(output, expected)
+        row_result["similarity"] = levenshtein_similarity(output, expected)
+        if row_result["exact_match"]:
+            correct += 1
+        results.append(row_result)
+    duration = time.time() - start
+
+    total = len(dataset)
+    print(f"Model: {args.model}")
+    print(f"Dataset: {Path(args.dataset).name}")
+    if total:
+        print(f"Accuracy: {correct/total*100:.1f}%")
+        print(f"Avg Latency: {duration/total:.2f}s")
+
+    if args.save:
+        with open(args.save, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace repository with minimal local evaluation toolkit
- add runnable `run_eval.py` script, dataset sample, and modular model/metrics helpers
- rewrite README for clean installation and usage instructions

## Testing
- `pip install -r requirements.txt`
- `python run_eval.py --model echo --dataset datasets/simple_qa.jsonl --save results/output.json`


------
https://chatgpt.com/codex/tasks/task_e_6899ba1fd9708322a39dde630dbbdd6e